### PR TITLE
Lock nixos version to 2.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/nixos/nix
+FROM docker.io/nixos/nix:2.3
 
 RUN nix-channel --add https://nixos.org/channels/nixpkgs-unstable nixpkgs
 RUN nix-channel --update


### PR DESCRIPTION
Ran into issues with command not found errors in the latest nixos version.